### PR TITLE
Update to use native Promise + other new Node features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-- '0.11'
-- '0.10'
+- 'stable'
+- '5'
 deploy:
   provider: npm
   email: bvdrucker@gmail.com

--- a/index.js
+++ b/index.js
@@ -1,16 +1,11 @@
 'use strict';
 
 var EventEmitter = require('events').EventEmitter;
-var Promise      = require('bluebird');
-
 function emitThen (event) {
   var args = Array.prototype.slice.call(arguments, 1);
   /* jshint validthis:true */
   return Promise
-    .bind(this)
-    .return(this)
-    .call('listeners', event)
-    .map(function (listener) {
+    .all(this.listeners(event).map(listener => Promise.resolve().then(() => {
       var a1 = args[0], a2 = args[1];
       switch (args.length) {
         case 0: return listener.call(this);
@@ -18,8 +13,8 @@ function emitThen (event) {
         case 2: return listener.call(this, a1, a2);
         default: return listener.apply(this, args);
       }
-    })
-    .return(null);
+    })))
+    .then(() => null);
 }
 
 emitThen.register = function () {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var EventEmitter = require('events').EventEmitter;
 function emitThen (event) {
   var args = Array.prototype.slice.call(arguments, 1);
   /* jshint validthis:true */
@@ -18,7 +17,7 @@ function emitThen (event) {
 }
 
 emitThen.register = function () {
-  EventEmitter.prototype.emitThen = emitThen;
+  require('events').prototype.emitThen = emitThen;
 };
 
 module.exports = emitThen;

--- a/package.json
+++ b/package.json
@@ -21,9 +21,10 @@
     "url": "https://github.com/bendrucker/emit-then/issues"
   },
   "homepage": "https://github.com/bendrucker/emit-then",
-  "dependencies": {
-    "bluebird": "2"
+  "engines": {
+    "node": ">=5"
   },
+  "dependencies": {},
   "devDependencies": {
     "chai": "1",
     "chai-as-promised": "4",

--- a/test.js
+++ b/test.js
@@ -7,7 +7,6 @@ var chai         = require('chai');
 var expect       = chai.expect;
 var sinon        = require('sinon');
 var EventEmitter = require('events').EventEmitter;
-var Promise      = require('bluebird');
 var emitThen     = require('./');
 
 chai
@@ -51,14 +50,14 @@ describe('emit-then', function () {
 
   it('preserves the context for the handlers', function () {
     emitter.on('event', spy);
-    return emitter.emitThen('event').finally(function () {
+    return emitter.emitThen('event').catch().then(function () {
       expect(spy).to.have.been.calledOn(emitter);
     });
   });
 
   it('preserves the arguments for the handlers', function () {
     emitter.on('event', spy);
-    return emitter.emitThen('event', 'foo', 'bar').finally(function () {
+    return emitter.emitThen('event', 'foo', 'bar').catch().then(function () {
       expect(spy).to.have.been.calledWith('foo', 'bar');
     });
   });


### PR DESCRIPTION
I really like the concept of this module and will start using it in a project of mine.

Looking at the code though, I couldn't help but notice that the module currently uses `Bluebird` for the Promises, which feels a bit overkill for the use case. Since Node.js nowadays support native Promises I think it would be preferable for a small module like this one to use that and to have any user of the module convert the native Promise to a Bluebird Promise in the places they desire the additional capabilities that provide.

So this PR converts the module to native Promises and makes use of the arrow functions that are supported since Node 5 to make the Promise code a bit nicer thanks to theirs lexical `this`.

I also threw in a change that no longer accesses the `EventEmitter` class as a property of the `events` module as that's no longer needed + moved the inclusion of the `events` module to only happen when someone wants to extend the global object.

What are your thoughts on this? Are you positive to the idea of a new version geared towards Node 5?
