### PR TITLE
use babel to get back node 0.10 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ results
 
 npm-debug.log
 node_modules
+dist

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,1 @@
-**/.*
-test.js
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 node_js:
 - 'stable'
 - '5'
+- '0.10'
+- '0.11'
 deploy:
   provider: npm
   email: bvdrucker@gmail.com

--- a/package.json
+++ b/package.json
@@ -2,9 +2,11 @@
   "name": "emit-then",
   "version": "2.0.0",
   "description": "EventEmitter.emit that wraps event calls in a promise",
-  "main": "index.js",
+  "main": "dist/index.js",
   "scripts": {
-    "test": "mocha test.js"
+    "compile": "babel --optional runtime -d dist/ src/",
+    "prepublish": "npm run compile",
+    "test": "mocha --compilers js:babel-core/register test.js"
   },
   "repository": {
     "type": "git",
@@ -24,12 +26,16 @@
   "engines": {
     "node": ">=5"
   },
-  "dependencies": {},
   "devDependencies": {
     "chai": "1",
     "chai-as-promised": "4",
     "mocha": "2",
     "sinon": "1",
-    "sinon-chai": "2"
+    "sinon-chai": "2",
+    "babel": "^5.8.34",
+    "babel-core": "^5.8.34"
+  },
+  "dependencies": {
+    "babel-runtime": "^5.8.34"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ function emitThen (event) {
 }
 
 emitThen.register = function () {
-  require('events').prototype.emitThen = emitThen;
+  require('events').EventEmitter.prototype.emitThen = emitThen;
 };
 
 module.exports = emitThen;


### PR DESCRIPTION
I'm depending on this package in a package that still work with node 0.10, and I want it to keep working with node 0.10, because 0.10 is still better at detection of some errors (like int/string type errors, some undefined variable detection,..). And it's anyway a good idea to keep compatibility.

If you don't want that kind of thing in this module, fine, I'll do a emit-then-compat or something.
